### PR TITLE
fix(umami): 修复 swup 导致的 umami 重复计数 bug

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -161,7 +161,7 @@ const bannerOffset =
 		<link rel="alternate" type="application/rss+xml" title={profileConfig.name} href={`${Astro.site}rss.xml`}/>
 
 		<!-- Umami Analytics -->
-		<script defer src="https://stats.upxuu.com/script.js" data-website-id="cd983d6c-e011-489d-903f-4757ce41c14d"></script>
+		<script defer src="https://stats.upxuu.com/script.js" data-website-id="cd983d6c-e011-489d-903f-4757ce41c14d" data-swup-ignore-script></script>
 
 		<!-- Microsoft Clarity -->
 		<script type="text/javascript">


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/saicaca/fuwari/blob/main/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

===

哈喽呀小同学，首先先期待你的考试顺利呀。

## 现象

我发现了一个关于你的网站 Umami 重复计数 Bug 呢
总的来说，是因为 swup 导致的重复触发 head 获取 script 的问题

现在的现象就是因为 swup 每进入一个页面都会触发 head，
但是因为 ViewTransition 的存在，原先的 umami 脚本还在，
最后就变得进入 x 个页面之后浏览器就有多少个 umami 脚本
（然后每个脚本访问新页面之后都会 POST 你的统计地址 /send）

<img width="2560" height="1600" alt="Untitled" src="https://github.com/user-attachments/assets/aff72075-2d21-4b27-b069-090aedd0250a" />

比如图片那样

在你的Umami Realtime界面也能看到“明明访问了一次但是会有好几次请求这个页面的现象”

## 修正

在 swup 的页面有提到：[Scripts Plugin — swup](https://swup.js.org/plugins/scripts-plugin/)

swup 会忽略带有 `data-swup-ignore-script` 属性的标签，
因此修复就是加上这个标签就好。